### PR TITLE
Add Saga Unit Tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -146,6 +146,10 @@ csharp_style_expression_bodied_local_functions = false:silent
 ###############################
 # VB Coding Conventions       #
 ###############################
+
+# IDE0005: Using directive is unnecessary.
+dotnet_diagnostic.IDE0005.severity = warning
+
 [*.vb]
 # Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/ContributorVerifiedEventTests.cs
+++ b/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/ContributorVerifiedEventTests.cs
@@ -1,8 +1,5 @@
 ﻿using FluentAssertions;
-using FluentAssertions.Execution;
 using NServiceBus.Testing;
-using NServiceBusTutorial.Core.ContributorAggregate;
-using NServiceBusTutorial.Core.ContributorAggregate.Commands;
 using NServiceBusTutorial.Core.ContributorAggregate.Events;
 using NServiceBusTutorial.Saga;
 using Xunit;
@@ -20,30 +17,5 @@ public class ContributorVerifiedEventTests
     var result = await saga.Handle(message, context);
 
     result.Completed.Should().BeTrue();
-  }
-
-  [Fact]
-  public async Task ShouldInitializeSagaAndMarkAsCompleted()
-  {
-    int expectedContributorId = 1;
-    var startMessage = new StartContributorVerificationCommand()
-    {
-      ContributorId = expectedContributorId
-    };
-    var message = new ContributorVerifiedEvent()
-    {
-      ContributorId = expectedContributorId
-    };
-    var saga = new TestableSaga<ContributorVerificationSaga, ContributorVerificationSagaData>();
-    var context = new TestableMessageHandlerContext();
-
-    var result = await saga.Handle(startMessage, context);
-    using var assertionScope = new AssertionScope();
-    result.SagaDataSnapshot.ContributorId.Should().Be(expectedContributorId);
-
-    result = await saga.Handle(message, context);
-    result.Completed.Should().BeTrue();
-    var timeoutMessage = result.FindTimeoutMessage<ContributorVerificationSagaTimeout>();
-    timeoutMessage.Should().NotBeNull();
   }
 }

--- a/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/ContributorVerifiedEventTests.cs
+++ b/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/ContributorVerifiedEventTests.cs
@@ -11,11 +11,11 @@ public class ContributorVerifiedEventTests
   public async Task ShouldMarkSagaAsCompleted()
   {
     var message = new ContributorVerifiedEvent();
-    var saga = new TestableSaga<ContributorVerificationSaga, ContributorVerificationSagaData>();
+    var saga = new ContributorVerificationSaga();
     var context = new TestableMessageHandlerContext();
 
-    var result = await saga.Handle(message, context);
+    await saga.Handle(message, context);
 
-    result.Completed.Should().BeTrue();
+    saga.Completed.Should().BeTrue();
   }
 }

--- a/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/SagaScenarioTests.cs
+++ b/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/SagaScenarioTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using NServiceBus.Testing;
+using NServiceBusTutorial.Core.ContributorAggregate.Commands;
+using NServiceBusTutorial.Core.ContributorAggregate.Events;
+using NServiceBusTutorial.Saga;
+using Xunit;
+
+namespace NServiceBusTutorial.UnitTests.ContributorVerificationSagaTests;
+
+public class SagaScenarioTests
+{
+  [Fact]
+  public async Task ShouldInitializeSagaAndMarkAsCompleted()
+  {
+    int expectedContributorId = 1;
+    var startMessage = new StartContributorVerificationCommand()
+    {
+      ContributorId = expectedContributorId
+    };
+    var message = new ContributorVerifiedEvent()
+    {
+      ContributorId = expectedContributorId
+    };
+    var saga = new TestableSaga<ContributorVerificationSaga, ContributorVerificationSagaData>();
+    var context = new TestableMessageHandlerContext();
+
+    var result = await saga.Handle(startMessage, context);
+
+    using var assertionScope = new AssertionScope();
+    result.SagaDataSnapshot.ContributorId.Should().Be(expectedContributorId);
+
+    result = await saga.Handle(message, context);
+    result.Completed.Should().BeTrue();
+    var timeoutMessage = result.FindTimeoutMessage<ContributorVerificationSagaTimeout>();
+    timeoutMessage.Should().NotBeNull();
+  }
+}

--- a/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/StartContributorVerificationCommandTests.cs
+++ b/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/StartContributorVerificationCommandTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using NServiceBus.Testing;
+using NServiceBusTutorial.Core.ContributorAggregate.Commands;
+using NServiceBusTutorial.Saga;
+using Xunit;
+
+namespace NServiceBusTutorial.UnitTests.ContributorVerificationSagaTests;
+
+public class StartContributorVerificationCommandTests
+{
+  [Fact]
+  public async Task ShouldSendVerifyContributorCommand()
+  {
+    var message = new StartContributorVerificationCommand();
+    var saga = new ContributorVerificationSaga
+    {
+      Data = new()
+    };
+    var context = new TestableMessageHandlerContext();
+
+    await saga.Handle(message, context);
+
+    var sentMessage = context.FindSentMessage<VerifyContributorCommand>();
+    sentMessage.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task ShouldSetContributorIdOnSagaState()
+  {
+    var message = new StartContributorVerificationCommand()
+    {
+      ContributorId = 4680
+    };
+    var saga = new ContributorVerificationSaga
+    {
+      Data = new()
+    };
+    var context = new TestableMessageHandlerContext();
+
+    await saga.Handle(message, context);
+
+    saga.Data.ContributorId.Should().Be(message.ContributorId);
+  }
+}

--- a/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/StartContributorVerificationCommandTests.cs
+++ b/tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/StartContributorVerificationCommandTests.cs
@@ -23,22 +23,4 @@ public class StartContributorVerificationCommandTests
     var sentMessage = context.FindSentMessage<VerifyContributorCommand>();
     sentMessage.Should().NotBeNull();
   }
-
-  [Fact]
-  public async Task ShouldSetContributorIdOnSagaState()
-  {
-    var message = new StartContributorVerificationCommand()
-    {
-      ContributorId = 4680
-    };
-    var saga = new ContributorVerificationSaga
-    {
-      Data = new()
-    };
-    var context = new TestableMessageHandlerContext();
-
-    await saga.Handle(message, context);
-
-    saga.Data.ContributorId.Should().Be(message.ContributorId);
-  }
 }


### PR DESCRIPTION
This pull request includes changes to improve code quality and organization in the `NServiceBusTutorial` unit tests and configuration files. The most important changes include adding a new test class for the `StartContributorVerificationCommand`, moving an existing test to a new file, and updating the `.editorconfig` file to include a new coding convention.

Improvements to unit tests:

* [`tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/StartContributorVerificationCommandTests.cs`](diffhunk://#diff-fc2f814a3c029b35445a0c02670ced78b1589fcfe007407e29493aed387f5dd9R1-R26): Added a new test class `StartContributorVerificationCommandTests` to verify that the `StartContributorVerificationCommand` sends the `VerifyContributorCommand`.
* [`tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/SagaScenarioTests.cs`](diffhunk://#diff-86017b5c9f3fea59e0ba1c6fde43f65afd0b8f3a95edc769d0c4353f446eb079R1-R38): Moved the `ShouldInitializeSagaAndMarkAsCompleted` test from `ContributorVerifiedEventTests` to a new file `SagaScenarioTests`.
* [`tests/NServiceBusTutorial.UnitTests/ContributorVerificationSagaTests/ContributorVerifiedEventTests.cs`](diffhunk://#diff-504ffc0624933ee7e5ec971fab819b2e0883478781d33ed3a13c07bc46e04438L24-L48): Removed the `ShouldInitializeSagaAndMarkAsCompleted` test as it has been moved to `SagaScenarioTests`.

Configuration updates:

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR149-R152): Added a new rule to set the severity of `IDE0005` (unnecessary using directive) to warning.