### PR TITLE
Update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,46 +1,46 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Ardalis.GuardClauses" Version="4.6.0" />
+    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageVersion Include="Ardalis.HttpClientTestExtensions" Version="4.2.0" />
     <PackageVersion Include="Ardalis.ListStartupServices" Version="1.1.4" />
-    <PackageVersion Include="Ardalis.Result" Version="9.1.0" />
-    <PackageVersion Include="Ardalis.Result.AspNetCore" Version="9.1.0" />
+    <PackageVersion Include="Ardalis.Result" Version="10.0.0" />
+    <PackageVersion Include="Ardalis.Result.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Ardalis.SharedKernel" Version="1.6.0" />
-    <PackageVersion Include="Ardalis.SmartEnum" Version="8.0.0" />
+    <PackageVersion Include="Ardalis.SmartEnum" Version="8.1.0" />
     <PackageVersion Include="Ardalis.Specification" Version="8.0.0" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FastEndpoints" Version="5.28.0" />
+    <PackageVersion Include="FastEndpoints" Version="5.30.0" />
     <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="5.28.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="5.30.0" />
     <PackageVersion Include="FastEndpoints.Swagger.Swashbuckle" Version="2.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="MailKit" Version="4.7.1.1" />
-    <PackageVersion Include="MediatR" Version="12.4.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="MailKit" Version="4.8.0" />
+    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.4" />
-    <PackageVersion Include="NServiceBus" Version="9.1.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
+    <PackageVersion Include="NServiceBus" Version="9.2.2" />
     <PackageVersion Include="NServiceBus.Extensions.Hosting" Version="3.0.0" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.3.8" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageVersion Include="ReportGenerator" Version="5.3.11" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageVersion Include="SQLite" Version="3.13.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBusTutorial.Web/Contributors/Verify.cs
+++ b/src/NServiceBusTutorial.Web/Contributors/Verify.cs
@@ -1,9 +1,4 @@
-﻿using Ardalis.Result;
-using NServiceBusTutorial.UseCases.Contributors.Get;
-using NServiceBusTutorial.UseCases.Contributors.Update;
-using FastEndpoints;
-using MediatR;
-using NServiceBus;
+﻿using FastEndpoints;
 using NServiceBusTutorial.Core.ContributorAggregate.Events;
 using Ardalis.SharedKernel;
 using NServiceBusTutorial.Core.ContributorAggregate;

--- a/src/NServiceBusTutorial.Web/NServiceBusTutorial.Web.csproj
+++ b/src/NServiceBusTutorial.Web/NServiceBusTutorial.Web.csproj
@@ -15,7 +15,10 @@
     <PackageReference Include="FastEndpoints" />
     <PackageReference Include="FastEndpoints.Swagger" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" PrivateAssets="All" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" />
     <PackageReference Include="Serilog.AspNetCore" />


### PR DESCRIPTION
This pull request includes several updates to package versions, code cleanup, and project configuration changes. The most important changes include updating various package versions in `Directory.Packages.props`, removing unused imports in `Verify.cs`, and modifying the `Microsoft.EntityFrameworkCore.Design` package reference in the project file.

### Package Updates:
* Updated multiple package versions in `Directory.Packages.props`, including `Ardalis.GuardClauses`, `Ardalis.Result`, `FluentAssertions`, `MailKit`, `MediatR`, `Microsoft.EntityFrameworkCore.*`, `Microsoft.Extensions.*`, `Microsoft.NET.Test.Sdk`, `NServiceBus`, `ReportGenerator`, `Serilog.AspNetCore`, and `xunit`.

### Code Cleanup:
* Removed unused imports in `src/NServiceBusTutorial.Web/Contributors/Verify.cs`.

### Project Configuration:
* Modified the `Microsoft.EntityFrameworkCore.Design` package reference in `src/NServiceBusTutorial.Web/NServiceBusTutorial.Web.csproj` to include `PrivateAssets` and `IncludeAssets` attributes.